### PR TITLE
Remove Org.Mentalis dependency from Nuspec

### DIFF
--- a/SocksWebProxy/SocksWebProxy.csproj
+++ b/SocksWebProxy/SocksWebProxy.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+1<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
@@ -12,7 +12,7 @@
     <PackageTags>Net4 SocksWebProxy NetStandard</PackageTags>
     <Company>Landon Key</Company>
     <Authors>https://github.com/lloydsparkes/SocksWebProxy/graphs/contributors</Authors>
-    <Version>1.4.0.0</Version>
+    <Version>1.4.0.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>DotNet4.SocksWebProxy</PackageId>
   </PropertyGroup>
@@ -20,6 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Org.Mentalis\Org.Mentalis.csproj">
       <Private>true</Private>
+      <PrivateAssets>all</PrivateAssets>
     </ProjectReference>
   </ItemGroup>
   


### PR DESCRIPTION
Currently the nuspec file generated seems to force a dependency for the Org.Mentalis package - this doesn't exist.
![image](https://user-images.githubusercontent.com/6608414/32675954-95dd6a1e-c6bd-11e7-9bad-cccc446c034c.png)

This PR Nuget to not expose the org.Mentalis package to dependant projects, however the prior nuget fix will copy across the binary and so the package works as expected.
![image](https://user-images.githubusercontent.com/6608414/32675929-88bacaa2-c6bd-11e7-9dfc-d4f3c16f17ba.png)

Picture below is the end result in a consumers bin directory.
![image](https://user-images.githubusercontent.com/6608414/32676050-01dd5d5a-c6be-11e7-9ee5-383ed8e91c3c.png)

Still feels a little bit like a hack, but as far as I can tell there is no easy way to get this functionality without doing this 👍 

References:
https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files

